### PR TITLE
Npc Buffer cleanup. Move spells to conf

### DIFF
--- a/conf/npc_buffer.conf.dist
+++ b/conf/npc_buffer.conf.dist
@@ -22,9 +22,4 @@ Buff.CureRes = 1
 # Fun Stuff
 # Put this spell if you want to kill your players : 48612 (Dalron the Controller)
 
-Buff.ID1 = 
-Buff.ID2 = 43223
-Buff.ID3 = 48469
-Buff.ID4 = 48074
-Buff.ID5 = 48170
-Buff.ID6 = 36880
+Buff.Spells = "43223;48469;48074;48170;36880;"

--- a/src/npc_buffer.cpp
+++ b/src/npc_buffer.cpp
@@ -59,7 +59,7 @@ Creates a one-click Buff NPC with emotes.
 
 #include "Config.h"
 #include "ScriptPCH.h"
-
+#include "Configuration/Config.h"
 
 class BufferAnnounce : public PlayerScript
 {
@@ -117,7 +117,6 @@ public:
     }
 };
 
-
 class npc_buffer : public WorldScript
 {
 public:
@@ -140,7 +139,6 @@ public:
         }
     }
 };
-
 
 void AddNPCBufferScripts()
 {

--- a/src/npc_buffer.cpp
+++ b/src/npc_buffer.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 
 # Buffer NPC #
 
@@ -59,7 +59,7 @@ Creates a one-click Buff NPC with emotes.
 
 #include "Config.h"
 #include "ScriptPCH.h"
-#include "Configuration/Config.h"
+
 
 class BufferAnnounce : public PlayerScript
 {
@@ -87,28 +87,26 @@ public:
 
     bool OnGossipSelect(Player * player, Creature * creature, uint32 /*uiSender*/, uint32 uiAction)
     {
-        // Get spells from config
-        const uint32 Buff1 = sConfigMgr->GetIntDefault("Buff.ID1", NULL); // Prayer of Fortitude
-        const uint32 Buff2 = sConfigMgr->GetIntDefault("Buff.ID2", NULL); // Greater Blessing of Kings
-        const uint32 Buff3 = sConfigMgr->GetIntDefault("Buff.ID3", NULL); // Mark of the Wild
-        const uint32 Buff4 = sConfigMgr->GetIntDefault("Buff.ID4", NULL); // Prayer of Spirit
-        const uint32 Buff5 = sConfigMgr->GetIntDefault("Buff.ID5", NULL); // Prayer of Shadow Protection
-        const uint32 Buff6 = sConfigMgr->GetIntDefault("Buff.ID6", NULL); // Arcane Intellect
+        std::vector<uint32> vecBuffs;
+        std::stringstream ss(sConfigMgr->GetStringDefault("Buff.Spells", ""));
+
+        for (std::string buff; std::getline(ss, buff, ';');)
+        {
+            vecBuffs.push_back(stoul(buff));
+        }
 
         // Remove Ressurection Sickness?
-        if (sConfigMgr->GetBoolDefault("Buff.CureRes", true))
+        if (sConfigMgr->GetBoolDefault("Buff.CureRes", 0))
         {
             // Remove Debuffs
             player->RemoveAura(15007, true);	// Cure Ressurection Sickness
         }
 
         // Apply Buffs
-        creature->CastSpell(player, Buff1, true);
-        creature->CastSpell(player, Buff2, true);
-        creature->CastSpell(player, Buff3, true);
-        creature->CastSpell(player, Buff4, true);
-        creature->CastSpell(player, Buff5, true);
-        creature->CastSpell(player, Buff6, true);
+
+        for (std::vector<uint32>::const_iterator itr = vecBuffs.begin(); itr != vecBuffs.end(); itr++)
+            player->CastSpell(player, *itr, true);
+        
 
         // NPC Emote
         creature->HandleEmoteCommand(EMOTE_ONESHOT_FLEX);
@@ -118,6 +116,7 @@ public:
         return true;
     }
 };
+
 
 class npc_buffer : public WorldScript
 {
@@ -141,6 +140,7 @@ public:
         }
     }
 };
+
 
 void AddNPCBufferScripts()
 {

--- a/src/npc_buffer.cpp
+++ b/src/npc_buffer.cpp
@@ -96,7 +96,7 @@ public:
         }
 
         // Remove Ressurection Sickness?
-        if (sConfigMgr->GetBoolDefault("Buff.CureRes", 0))
+        if (sConfigMgr->GetBoolDefault("Buff.CureRes", true))
         {
             // Remove Debuffs
             player->RemoveAura(15007, true);	// Cure Ressurection Sickness


### PR DESCRIPTION
The player should cast the buffs on himself, there are weird problems when the creature attempts to do it. This change removes the repetitiveness and makes it easier to add and remove spells through the conf file.

Tested & working for me